### PR TITLE
non-global registry for metrics

### DIFF
--- a/prometheus-client/prometheus-client.cabal
+++ b/prometheus-client/prometheus-client.cabal
@@ -34,6 +34,7 @@ library
     , Prometheus.Metric.Vector
     , Prometheus.MonadMonitor
     , Prometheus.Registry
+    , Prometheus.Registry.Local
   build-depends:
       atomic-primops     >=0.4
     , base               >=4.7 && <5

--- a/prometheus-client/prometheus-client.cabal
+++ b/prometheus-client/prometheus-client.cabal
@@ -21,6 +21,7 @@ library
   default-language:    Haskell2010
   exposed-modules:
       Prometheus
+    , Prometheus.Registry.Local
   other-modules:
       Prometheus.Info
     , Prometheus.Label
@@ -34,7 +35,6 @@ library
     , Prometheus.Metric.Vector
     , Prometheus.MonadMonitor
     , Prometheus.Registry
-    , Prometheus.Registry.Local
   build-depends:
       atomic-primops     >=0.4
     , base               >=4.7 && <5

--- a/prometheus-client/src/Prometheus.hs
+++ b/prometheus-client/src/Prometheus.hs
@@ -14,6 +14,7 @@ module Prometheus (
 -- * Exporting
 
 ,   exportMetricsAsText
+,   exportLocalMetricsAsText
 
 -- * Metrics
 --

--- a/prometheus-client/src/Prometheus/Export/Text.hs
+++ b/prometheus-client/src/Prometheus/Export/Text.hs
@@ -1,18 +1,18 @@
 {-# language OverloadedStrings #-}
 
 module Prometheus.Export.Text (
-    exportMetricsAsText
+    exportMetricsAsText,
+    exportLocalMetricsAsText
 ) where
 
 import Prometheus.Info
 import Prometheus.Metric
 import Prometheus.Registry
+import qualified Prometheus.Registry.Local as Local
 
 import Control.Monad.IO.Class
 import qualified Data.ByteString.Builder as Build
 import qualified Data.ByteString.Lazy as BS
-import Data.Foldable (foldMap)
-import Data.Monoid ((<>), mempty, mconcat)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -39,6 +39,12 @@ import qualified Data.Text.Encoding as T
 exportMetricsAsText :: MonadIO m => m BS.ByteString
 exportMetricsAsText = do
     samples <- collectMetrics
+    return $ Build.toLazyByteString $ foldMap exportSampleGroup samples
+
+-- | Export a particular registry as text. No globals are used.
+exportLocalMetricsAsText :: MonadIO m => Local.Registry -> m BS.ByteString
+exportLocalMetricsAsText rg = do
+    samples <- Local.collect rg
     return $ Build.toLazyByteString $ foldMap exportSampleGroup samples
 
 exportSampleGroup :: SampleGroup -> Build.Builder

--- a/prometheus-client/src/Prometheus/Registry/Local.hs
+++ b/prometheus-client/src/Prometheus/Registry/Local.hs
@@ -1,0 +1,61 @@
+-- |
+-- =
+--
+-- This module is just like Prometheus.Registry, except that it does not use a
+-- global TVar, so it's possible to have more than one registry in the same
+-- executable.
+--
+-- The interface exposed is mostly STM, which gives the user finer-grained
+-- control of the registry.
+module Prometheus.Registry.Local (
+    Registry
+  , newRegistry
+  , newRegistryIO
+  , register
+  , registerIO
+  , collect
+  , STM.atomically
+  ) where
+
+import Prometheus.Metric
+
+import Control.Monad.IO.Class
+import Control.Concurrent.STM (STM, TVar)
+import qualified Control.Concurrent.STM as STM
+
+-- | A 'Registry' is a list of all registered metrics, currently represented by
+-- their sampling functions.
+type Registry = TVar [IO [SampleGroup]]
+
+-- | Create a new registry. There is no need to close it explicity, it's left
+-- to the garbage collector. To avoid memory leaks, it's sensible to treat it
+-- like a proper resource and use a bracket pattern where it's not used outside
+-- of the continuation.
+newRegistry :: STM Registry
+newRegistry = STM.newTVar []
+
+-- | 'newRegistry' but in IO.
+newRegistryIO :: IO Registry
+newRegistryIO = STM.newTVarIO []
+
+-- | Register a metric. The metric cannot be un-registered.
+register :: Registry -> IO [SampleGroup] -> STM ()
+register rg sampleGroupsIO = STM.modifyTVar' rg (sampleGroupsIO:)
+
+-- | Like 'register' but the metrics is constructed in IO and then the register
+-- STM transaction is executed.
+registerIO :: MonadIO m => Registry -> Metric s -> m s
+registerIO rg (Metric mk) = liftIO (mk >>= \(s, sampleGroupsIO) -> do
+  _ <- STM.atomically (register rg sampleGroupsIO)
+  pure s)
+
+-- | Collect samples from all currently registered metrics. In typical use cases
+-- there is no reason to use this function, instead you should use
+-- `exportLocalMetricsAsText` or a convenience library.
+--
+-- This function is likely only of interest if you wish to export metrics in
+-- a non-supported format for use with another monitoring service.
+collect :: MonadIO m => Registry -> m [SampleGroup]
+collect rg = liftIO $ do
+    registry <- STM.atomically $ STM.readTVar rg
+    concat <$> sequence registry


### PR DESCRIPTION
Gives a variant of the existing registry that doesn't have a global `TVar`.